### PR TITLE
chore: module読み込みの簡潔化

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,6 @@
 	<link href="https://fonts.googleapis.com/css?family=Baloo+Bhai&display=swap" rel="stylesheet">
 	<link rel="stylesheet" href="css/reset.css">
 	<link rel="stylesheet" href="css/style.css">
-	<script type="module" src="js/common.js"></script>
 	<script type="module" src="js/index.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/locale/ja.js"></script>

--- a/js/p.js
+++ b/js/p.js
@@ -1,4 +1,4 @@
-import impl from "./common";
+import * as impl from "./common.js";
 function $(id) {
 	return document.getElementById(id);
 }

--- a/p.html
+++ b/p.html
@@ -8,8 +8,7 @@
 	<link href="https://fonts.googleapis.com/css?family=Baloo+Bhai&display=swap" rel="stylesheet">
 	<link rel="stylesheet" href="css/reset.css">
 	<link rel="stylesheet" href="css/style.css">
-	<script src="js/common.js"></script>
-	<script src="js/p.js"></script>
+	<script type="module" src="js/p.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/locale/ja.js"></script>
 </head>

--- a/v2/p.html
+++ b/v2/p.html
@@ -8,7 +8,7 @@
 	<link href="https://fonts.googleapis.com/css?family=Baloo+Bhai&display=swap" rel="stylesheet">
 	<link rel="stylesheet" href="../css/reset.css">
 	<link rel="stylesheet" href="../css/style.css">
-	<script type="module" src="js/common.js"></script>
+	<script src="js/common.js"></script>
 	<script src="js/p.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/locale/ja.js"></script>


### PR DESCRIPTION
from https://github.com/hidao80/mastogetter/pull/62#discussion_r365324357

esmoduleとしてimportしてたらHTML側で改めて指定する必要はないので削除して簡潔に。

また、誤って`v2`の方を #62 でいじってしまっていたようなのでrevert
