### PR TITLE
fix: カードを削除したときにcard_listが二重削除されていた問題を修正

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -32,7 +32,6 @@ export const get_url_vars = (function() {
 export function deleteCard(index, prefix) {
 	$("cards").removeChild($(`${prefix}_${index}`));
 	card_list.splice(index, 1);
-	delete card_list[index];
 	genPermalink();
 }
 


### PR DESCRIPTION
#62 でArray#spliceに書き換えたときに消し忘れた

resolve #92

ref:
- https://github.com/Qithub-BOT/mastogetter/commit/d50e36afe4304f53e166b15e83058ddce71da7e8#diff-42f69825340f0b5fa628d80900a46daaL65-R85
