### PR TITLE
flipするなどした後でカードを削除しようとすると表示とpermalinkに差異が出る問題を取り急ぎ解消する。

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -30,8 +30,17 @@ export const get_url_vars = (function() {
  * @param {string} prefix
  */
 export function deleteCard(index, prefix) {
-	$("cards").removeChild($(`${prefix}_${index}`));
-	card_list.splice(index, 1);
+	const card = $(`${prefix}_${index}`);
+	const cards = $("cards").childNodes;
+	let idx = 0;
+	for (let i = 0; i < cards.length; i++) {
+		if (cards[i] === card) {
+			idx = i;
+			break;
+		}
+	}
+	$("cards").removeChild(card);
+	card_list.splice(idx, 1);
 	genPermalink();
 }
 


### PR DESCRIPTION
issue: https://github.com/Qithub-BOT/mastogetter/issues/94

にて話し合われている問題、抜本的な解決については方針を定めるのに時間を要しそうなので
hotfix的に修正します。

パフォーマンス問題が出る可能性は否定できないけれど、 https://github.com/Qithub-BOT/mastogetter/pull/42 https://github.com/Qithub-BOT/mastogetter/pull/81 でも同じことをやっているので今更、と思うことにしておいてください。

動作確認を、お願いします🙏