### PR TITLE
fix(eslint): prefer-constの導入

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -41,6 +41,7 @@
 			}
 		],
 		"space-before-blocks": "error",
+		"prefer-const": "error",
 		"space-unary-ops": [
 			1,
 			{

--- a/js/index.js
+++ b/js/index.js
@@ -83,7 +83,7 @@ function addCard() {
 function flipCards() {
 	const cards = $("cards");
 	if (!cards) return;
-	let card_nodes = [];
+	const card_nodes = [];
 	while (cards.hasChildNodes()) {
 		if (cards.firstChild.nodeName !== "#text") {
 			card_nodes.push(cards.firstChild);


### PR DESCRIPTION
#95 で`let`ではなく`const`にできるよ、というたぐいのレビューをしたのだが、よく見たらeslintでそういうルールを有効にしていなかったので有効にする提案