### PR TITLE
feat: powerfull eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,6 +10,7 @@
 	"extends": [
 		"eslint:recommended",
 		"standard",
+		"plugin:jsdoc/recommended",
 		"plugin:prettier/recommended"
 	],
 	"parserOptions": {
@@ -50,6 +51,11 @@
 				"printWidth": 120,
 				"useTabs": true
 			}
-		]
+		],
+		"jsdoc/require-description": "off",
+		"jsdoc/require-jsdoc": "off",
+		"jsdoc/require-param-description": "off",
+		"jsdoc/require-returns-description": "off",
+		"jsdoc/valid-types": "off"
 	}
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -55,7 +55,6 @@
 		"jsdoc/require-description": "off",
 		"jsdoc/require-jsdoc": "off",
 		"jsdoc/require-param-description": "off",
-		"jsdoc/require-returns-description": "off",
-		"jsdoc/valid-types": "off"
+		"jsdoc/require-returns-description": "off"
 	}
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,6 +9,7 @@
 	},
 	"extends": [
 		"eslint:recommended",
+		"standard",
 		"plugin:prettier/recommended"
 	],
 	"parserOptions": {
@@ -16,7 +17,6 @@
 		"sourceType": "module"
 	},
 	"rules": {
-		"eqeqeq": "error",
 		"semi": [
 			"error",
 			"always"
@@ -40,27 +40,6 @@
 				"code": 120
 			}
 		],
-		"space-before-blocks": "error",
-		"prefer-const": "error",
-		"space-unary-ops": [
-			1,
-			{
-				"overrides": {
-					"typeof": false
-				}
-			}
-		],
-		"operator-linebreak": [
-			"error",
-			"after",
-			{
-				"overrides": {
-					"?": "before",
-					":": "before"
-				}
-			}
-		],
-		"no-useless-escape": "error",
 		"camelcase": "off",
 		"no-invalid-this": "error",
 		"prettier/prettier": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -41,7 +41,6 @@
 				"code": 120
 			}
 		],
-		"camelcase": "off",
 		"no-invalid-this": "error",
 		"prettier/prettier": [
 			"error",

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
 results
+.eslintcache

--- a/js/common.js
+++ b/js/common.js
@@ -69,7 +69,7 @@ function UncompressOrPassThroughTootId(id) {
 				}
 			}
 			// parsed[1]は10桁
-			return 0 === parsed[0] ? `${parsed[1]}` : `${parsed[0]}${`${parsed[1]}`.padStart(10, "0")}`;
+			return parsed[0] === 0 ? `${parsed[1]}` : `${parsed[0]}${`${parsed[1]}`.padStart(10, "0")}`;
 		}
 		default:
 			throw new Error("invalid id syntax.");
@@ -94,7 +94,7 @@ export function decodePermalink(searchParams) {
 			// 末尾が,で終わると空文字列が最終要素に来る
 			.filter(e => e !== "")
 			.map(id => UncompressOrPassThroughTootId(id))
-			.filter(e => null !== e),
+			.filter(e => e !== null),
 	};
 }
 
@@ -131,8 +131,8 @@ export function registerEventsToCard(element, index, prefix) {
  * @param {boolean | undefined} registerEvent
  */
 export function showCards(permalink_obj, registerEvent = false) {
-	const instance_full = permalink_obj["instance_full"];
-	const toot_ids = permalink_obj["toot_ids"];
+	const instance_full = permalink_obj.instance_full;
+	const toot_ids = permalink_obj.toot_ids;
 	const xhr = new XMLHttpRequest();
 	const target_div = $("cards");
 	let toot_url = "";
@@ -174,7 +174,7 @@ export function showCards(permalink_obj, registerEvent = false) {
 </div>`;
 					toot_div.setAttribute("id", `o_${idx}`);
 					toot_div.setAttribute("class", "toot");
-					if (true === registerEvent) {
+					if (registerEvent === true) {
 						registerEventsToCard(toot_div, idx, "o");
 					}
 					max_index++;

--- a/js/common.js
+++ b/js/common.js
@@ -1,5 +1,5 @@
-export let card_list = [];
-let max_index = 0;
+export let cardList = [];
+let maxIndex = 0;
 
 export function ready(loaded) {
 	if (["interactive", "complete"].includes(document.readyState)) {
@@ -28,7 +28,7 @@ export function deleteCard(index, prefix) {
 		}
 	}
 	$("cards").removeChild(card);
-	card_list.splice(idx, 1);
+	cardList.splice(idx, 1);
 	genPermalink();
 }
 
@@ -89,10 +89,10 @@ export function decodePermalink(searchParams) {
 	if (!searchParams.has("t")) {
 		throw new Error("t must be required.");
 	}
-	const instance_full = searchParams.has("i") ? searchParams.get("i") : "https://qiitadon.com";
+	const instanceFull = searchParams.has("i") ? searchParams.get("i") : "https://qiitadon.com";
 	return {
-		instance_full: instance_full,
-		instance: new URL(instance_full).hostname,
+		instance_full: instanceFull,
+		instance: new URL(instanceFull).hostname,
 		toot_ids: searchParams
 			.get("t")
 			.split(",")
@@ -109,7 +109,7 @@ export function genPermalink() {
 	const currentURL = new URL(location.href);
 	const path = currentURL.pathname.substring(0, currentURL.pathname.lastIndexOf("/") + 1);
 	const permalink = `${currentURL.origin}${path}p.html?i=${$("instance").value}&t=`;
-	$("permalink").value = permalink + card_list.map(id => CompressTootId(id)).join(",");
+	$("permalink").value = permalink + cardList.map(id => CompressTootId(id)).join(",");
 }
 
 /**
@@ -132,27 +132,27 @@ export function registerEventsToCard(element, index, prefix) {
 
 /**
  *
- * @param {{instance_full: string, instance: string, toot_ids: string[]}} permalink_obj created by `decodePermalink`
+ * @param {{instance_full: string, instance: string, toot_ids: string[]}} permalinkObj created by `decodePermalink`
  * @param {boolean | undefined} registerEvent
  */
-export function showCards(permalink_obj, registerEvent = false) {
-	const instance_full = permalink_obj.instance_full;
-	const toot_ids = permalink_obj.toot_ids;
+export function showCards(permalinkObj, registerEvent = false) {
+	const instanceFull = permalinkObj.instance_full;
+	const tootIds = permalinkObj.toot_ids;
 	const xhr = new XMLHttpRequest();
-	const target_div = $("cards");
-	let toot_url = "";
+	const targetDiv = $("cards");
+	let tootUrl = "";
 
-	for (let i = 0; i < toot_ids.length; i++) {
-		toot_url = instance_full + "/api/v1/statuses/" + toot_ids[i];
-		xhr.open("GET", toot_url, false);
+	for (let i = 0; i < tootIds.length; i++) {
+		tootUrl = instanceFull + "/api/v1/statuses/" + tootIds[i];
+		xhr.open("GET", tootUrl, false);
 		xhr.onload = function() {
 			if (xhr.readyState === 4) {
 				if (xhr.status === 200) {
-					const toot_div = document.createElement("div");
+					const tootDiv = document.createElement("div");
 					const toot = JSON.parse(xhr.responseText);
 					const timestamp = moment(toot.created_at).format("llll");
-					const content_html = getHtmlFromContent(toot.content);
-					const idx = max_index;
+					const contentHtml = getHtmlFromContent(toot.content);
+					const idx = maxIndex;
 					let media = "";
 					for (let i = 0; i < toot.media_attachments.length; i++) {
 						media += `
@@ -160,7 +160,7 @@ export function showCards(permalink_obj, registerEvent = false) {
 	<img class='thumbs' src='${toot.media_attachments[i].preview_url}'>
 </a>`;
 					}
-					toot_div.innerHTML = `
+					tootDiv.innerHTML = `
 <div class="box">
 	<a href="${toot.account.url}">
 		<img width="48" height="48" alt="" class="u-photo" src="${toot.account.avatar}">
@@ -173,18 +173,18 @@ export function showCards(permalink_obj, registerEvent = false) {
 	</a>
 	<a class="toot-time" href="${toot.url}">${timestamp}</a>
 	<div class="e-content" lang="ja" style="display: block; direction: ltr">
-		<p>${content_html}</p>
+		<p>${contentHtml}</p>
 	</div>
 	${media}
 </div>`;
-					toot_div.setAttribute("id", `o_${idx}`);
-					toot_div.setAttribute("class", "toot");
+					tootDiv.setAttribute("id", `o_${idx}`);
+					tootDiv.setAttribute("class", "toot");
 					if (registerEvent === true) {
-						registerEventsToCard(toot_div, idx, "o");
+						registerEventsToCard(tootDiv, idx, "o");
 					}
-					max_index++;
-					setAllAnchorsAsExternalTabSecurely(toot_div);
-					target_div.appendChild(toot_div);
+					maxIndex++;
+					setAllAnchorsAsExternalTabSecurely(tootDiv);
+					targetDiv.appendChild(tootDiv);
 				} else {
 					console.error(xhr.statusText);
 				}
@@ -196,7 +196,7 @@ export function showCards(permalink_obj, registerEvent = false) {
 		xhr.send(null);
 	}
 
-	card_list = card_list.concat(toot_ids);
+	cardList = cardList.concat(tootIds);
 	genPermalink();
 }
 
@@ -235,33 +235,33 @@ export function handleDrop(e) {
 	}
 	const cards = $("cards");
 	const children = cards.childNodes;
-	let src_index = -1;
-	let node_index = -1;
+	let srcIndex = -1;
+	let nodeIndex = -1;
 	for (let i = 0; i < children.length; i++) {
 		if (children[i] === src) {
-			src_index = i;
+			srcIndex = i;
 		}
 		if (children[i] === node) {
-			node_index = i;
+			nodeIndex = i;
 		}
 	}
-	if (src_index < 0) {
+	if (srcIndex < 0) {
 		return;
 	}
-	if (node_index < 0) {
+	if (nodeIndex < 0) {
 		return;
 	}
 
 	cards.removeChild(src);
 	cards.insertBefore(src, node);
 
-	if (src_index < node_index) {
-		card_list.splice(node_index, 0, card_list[src_index]);
-		card_list.splice(src_index, 1);
+	if (srcIndex < nodeIndex) {
+		cardList.splice(nodeIndex, 0, cardList[srcIndex]);
+		cardList.splice(srcIndex, 1);
 	} else {
-		const toot_id = card_list[src_index];
-		card_list.splice(src_index, 1);
-		card_list.splice(node_index, 0, toot_id);
+		const tootId = cardList[srcIndex];
+		cardList.splice(srcIndex, 1);
+		cardList.splice(nodeIndex, 0, tootId);
 	}
 	genPermalink();
 }
@@ -270,9 +270,9 @@ export function handleDragEnd() {
 	// console.log("drag end");
 }
 
-function getHtmlFromContent(str_content) {
+function getHtmlFromContent(strContent) {
 	const div = document.createElement("div");
-	div.innerHTML = str_content;
+	div.innerHTML = strContent;
 	return div.innerHTML;
 }
 

--- a/js/common.js
+++ b/js/common.js
@@ -34,7 +34,9 @@ export function deleteCard(index, prefix) {
 
 /**
  * idを36進数へ変換する
+ *
  * @param {string} id 10進数の文字列
+ * @returns {string}
  */
 function CompressTootId(id) {
 	if (id.length > 10) {
@@ -47,6 +49,7 @@ function CompressTootId(id) {
 
 /**
  * Toot Idを10進数に変換する
+ *
  * @param {string} id
  * @throws 10進数として変換できないか36進数2つが_で結合された文字列出ない場合エラー
  * @returns {string}
@@ -78,7 +81,9 @@ function UncompressOrPassThroughTootId(id) {
 
 /**
  * Permalinkの分解
+ *
  * @param {URLSearchParams} searchParams
+ * @returns {{instance_full: string, instance: string, toot_ids: string[]}}
  */
 export function decodePermalink(searchParams) {
 	if (!searchParams.has("t")) {

--- a/js/index.js
+++ b/js/index.js
@@ -5,18 +5,18 @@ function $(id) {
 }
 
 function showPreview() {
-	let instance_full = $("instance").value;
-	if (instance_full.trim() === "") {
-		instance_full = "https://qiitadon.com";
-		$("instance").value = instance_full;
+	let instanceFull = $("instance").value;
+	if (instanceFull.trim() === "") {
+		instanceFull = "https://qiitadon.com";
+		$("instance").value = instanceFull;
 	}
-	const toot_id = $("toot-id")
+	const tootId = $("toot-id")
 		.value.split("/")
 		.reverse()[0];
-	const toot_url = instance_full + "/api/v1/statuses/" + toot_id;
-	const target_div = $("card-preview");
+	const tootUrl = instanceFull + "/api/v1/statuses/" + tootId;
+	const targetDiv = $("card-preview");
 	const xhr = new XMLHttpRequest();
-	xhr.open("GET", toot_url, true);
+	xhr.open("GET", tootUrl, true);
 	xhr.onload = function() {
 		if (xhr.readyState === 4) {
 			if (xhr.status === 200) {
@@ -29,7 +29,7 @@ function showPreview() {
 	<img class='thumbs' src='${toot.media_attachments[i].preview_url}'>
 </a>`;
 				}
-				target_div.innerHTML = `
+				targetDiv.innerHTML = `
 <div class="toot">
 	<div class="box">
 		<a href="${toot.account.url}">
@@ -48,7 +48,7 @@ function showPreview() {
 	${media}
 	</div>
 </div>`;
-				impl.setAllAnchorsAsExternalTabSecurely(target_div);
+				impl.setAllAnchorsAsExternalTabSecurely(targetDiv);
 			} else {
 				console.error(xhr.statusText);
 			}
@@ -61,13 +61,13 @@ function showPreview() {
 }
 
 function addCard() {
-	const card_preview = $("card-preview");
-	if (!card_preview) return;
+	const cardPreview = $("card-preview");
+	if (!cardPreview) return;
 	const clone = $("card-preview").firstElementChild.cloneNode(true);
-	const len = impl.card_list.length;
+	const len = impl.cardList.length;
 	clone.setAttribute("id", `c_${len}`);
 	impl.registerEventsToCard(clone, len, "c");
-	impl.card_list.push(
+	impl.cardList.push(
 		$("toot-id")
 			.value.split("/")
 			.reverse()[0]
@@ -83,18 +83,18 @@ function addCard() {
 function flipCards() {
 	const cards = $("cards");
 	if (!cards) return;
-	const card_nodes = [];
+	const cardNodes = [];
 	while (cards.hasChildNodes()) {
 		if (cards.firstChild.nodeName !== "#text") {
-			card_nodes.push(cards.firstChild);
+			cardNodes.push(cards.firstChild);
 		}
 		cards.removeChild(cards.firstChild);
 	}
-	if (card_nodes.length === 0) return;
-	while (card_nodes.length > 0) {
-		cards.appendChild(card_nodes.pop());
+	if (cardNodes.length === 0) return;
+	while (cardNodes.length > 0) {
+		cards.appendChild(cardNodes.pop());
 	}
-	impl.card_list.reverse();
+	impl.cardList.reverse();
 	impl.genPermalink();
 }
 
@@ -109,9 +109,9 @@ function copyPermalink() {
 }
 
 function loadPermalink() {
-	const permalink_obj = impl.decodePermalink(new URL($("load").value).searchParams);
-	$("instance").value = permalink_obj.instance_full;
-	impl.showCards(permalink_obj, true);
+	const permalinkObj = impl.decodePermalink(new URL($("load").value).searchParams);
+	$("instance").value = permalinkObj.instance_full;
+	impl.showCards(permalinkObj, true);
 	// impl.showCardsより前に呼び出してはいけない
 	impl.genPermalink();
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -251,9 +251,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0.tgz",
-      "integrity": "sha512-yYkE07YF+6SIBmg1MsJ9dlub5L48Ek7X0qz+c/CPCHS9EBXfESorzng4cJQjJW5/pB6vDF41u7F8vUhLVDqIug==",
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.2.tgz",
+      "integrity": "sha512-YoKuru3Lyoy7yVTBSH2j7UxTqe/je3dWAruC0sHvZX1GNd5zX8SSLvQqEgO9b3Ex8IW+goFI9arEEsFIbulhOw==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
@@ -348,14 +348,20 @@
         "get-stdin": "^6.0.0"
       }
     },
+    "eslint-config-standard": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.0.tgz",
+      "integrity": "sha512-EF6XkrrGVbvv8hL/kYa/m6vnvmUT+K82pJJc4JJVMM6+Qgqh0pnwprSxdduDLB9p/7bIxD+YV5O0wfb8lmcPbA==",
+      "dev": true
+    },
     "eslint-import-resolver-node": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
-      "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz",
+      "integrity": "sha512-b8crLDo0M5RSe5YG8Pu2DYBj71tSB6OvXkfzwbJU2w7y8P4/yo0MyF8jU26IEuEuHF2K5/gcAJE3LhQGqBBbVg==",
       "dev": true,
       "requires": {
         "debug": "^2.6.9",
-        "resolve": "^1.5.0"
+        "resolve": "^1.13.1"
       },
       "dependencies": {
         "debug": {
@@ -376,9 +382,9 @@
       }
     },
     "eslint-module-utils": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.5.0.tgz",
-      "integrity": "sha512-kCo8pZaNz2dsAW7nCUjuVoI11EBXXpIzfNxmaoLhXoRDOnqXLC4iSGVRdZPhOitfbdEfMEfKOiENaK6wDPZEGw==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.5.2.tgz",
+      "integrity": "sha512-LGScZ/JSlqGKiT8OC+cYRxseMjyqt6QO54nl281CK93unD89ijSeRV6An8Ci/2nvWVKe8K/Tqdm75RQoIOCr+Q==",
       "dev": true,
       "requires": {
         "debug": "^2.6.9",
@@ -402,10 +408,37 @@
         }
       }
     },
+    "eslint-plugin-es": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.0.tgz",
+      "integrity": "sha512-6/Jb/J/ZvSebydwbBJO1R9E5ky7YeElfK56Veh7e4QGFHCXoIXGH9HhVz+ibJLM3XJ1XjP+T7rKBLUa/Y7eIng==",
+      "dev": true,
+      "requires": {
+        "eslint-utils": "^2.0.0",
+        "regexpp": "^3.0.0"
+      },
+      "dependencies": {
+        "eslint-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
+          "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
+        "regexpp": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
+          "integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g==",
+          "dev": true
+        }
+      }
+    },
     "eslint-plugin-import": {
-      "version": "2.19.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.19.1.tgz",
-      "integrity": "sha512-x68131aKoCZlCae7rDXKSAQmbT5DQuManyXo2sK6fJJ0aK5CWAkv6A6HJZGgqC8IhjQxYPgo6/IY4Oz8AFsbBw==",
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.20.0.tgz",
+      "integrity": "sha512-NK42oA0mUc8Ngn4kONOPsPB1XhbUvNHqF+g307dPV28aknPoiNnKLFd9em4nkswwepdF5ouieqv5Th/63U7YJQ==",
       "dev": true,
       "requires": {
         "array-includes": "^3.0.3",
@@ -449,6 +482,43 @@
         }
       }
     },
+    "eslint-plugin-node": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.0.0.tgz",
+      "integrity": "sha512-chUs/NVID+sknFiJzxoN9lM7uKSOEta8GC8365hw1nDfwIPIjjpRSwwPvQanWv8dt/pDe9EV4anmVSwdiSndNg==",
+      "dev": true,
+      "requires": {
+        "eslint-plugin-es": "^3.0.0",
+        "eslint-utils": "^2.0.0",
+        "ignore": "^5.1.1",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.10.1",
+        "semver": "^6.1.0"
+      },
+      "dependencies": {
+        "eslint-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
+          "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
+        "ignore": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+          "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
     "eslint-plugin-prettier": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz",
@@ -462,6 +532,12 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz",
       "integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==",
+      "dev": true
+    },
+    "eslint-plugin-standard": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.1.tgz",
+      "integrity": "sha512-v/KBnfyaOMPmZc/dmc6ozOdWqekGp7bBGq4jLAecEfPGmfKiWS4sA8sC0LqiV9w5qmXAtXVn4M3p1jSyhY85SQ==",
       "dev": true
     },
     "eslint-scope": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -177,6 +177,12 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "comment-parser": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.7.2.tgz",
+      "integrity": "sha512-4Rjb1FnxtOcv9qsfuaNuVsmmVn4ooVoBHzYfyKteiXwIU84PClyGA5jASoFMwPV93+FPh9spwueXauxFJZkGAg==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -478,6 +484,30 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-jsdoc": {
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-20.3.1.tgz",
+      "integrity": "sha512-JQ25OXvseVm84pX2mcVvKtGwrZDeAxgFUkq11f/pJpbGJMANYcLaMAUuW7U3cGhapWh+Gj04At/enAt26dpOeg==",
+      "dev": true,
+      "requires": {
+        "comment-parser": "^0.7.2",
+        "debug": "^4.1.1",
+        "jsdoctypeparser": "^6.1.0",
+        "lodash": "^4.17.15",
+        "object.entries-ponyfill": "^1.0.1",
+        "regextras": "^0.7.0",
+        "semver": "^6.3.0",
+        "spdx-expression-parse": "^3.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
       }
@@ -945,6 +975,12 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsdoctypeparser": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-6.1.0.tgz",
+      "integrity": "sha512-UCQBZ3xCUBv/PLfwKAJhp6jmGOSLFNKzrotXGNgbKhWvz27wPsCsVeP7gIcHPElQw2agBmynAitXqhxR58XAmA==",
+      "dev": true
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -1084,6 +1120,12 @@
         "has-symbols": "^1.0.0",
         "object-keys": "^1.0.11"
       }
+    },
+    "object.entries-ponyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object.entries-ponyfill/-/object.entries-ponyfill-1.0.1.tgz",
+      "integrity": "sha1-Kavfd8v70mVm3RqiTp2I9lQz0lY=",
+      "dev": true
     },
     "object.values": {
       "version": "1.1.1",
@@ -1283,6 +1325,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true
+    },
+    "regextras": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/regextras/-/regextras-0.7.0.tgz",
+      "integrity": "sha512-ds+fL+Vhl918gbAUb0k2gVKbTZLsg84Re3DI6p85Et0U0tYME3hyW4nMK8Px4dtDaBA2qNjvG5uWyW7eK5gfmw==",
       "dev": true
     },
     "resolve": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"eslint-config-prettier": "^6.9.0",
 		"eslint-config-standard": "^14.1.0",
 		"eslint-plugin-import": "^2.20.0",
+		"eslint-plugin-jsdoc": "^20.3.1",
 		"eslint-plugin-node": "^11.0.0",
 		"eslint-plugin-prettier": "^3.1.2",
 		"eslint-plugin-promise": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,12 @@
 	"devDependencies": {
 		"eslint": "^6.8.0",
 		"eslint-config-prettier": "^6.9.0",
-		"eslint-plugin-import": "^2.19.1",
+		"eslint-config-standard": "^14.1.0",
+		"eslint-plugin-import": "^2.20.0",
+		"eslint-plugin-node": "^11.0.0",
 		"eslint-plugin-prettier": "^3.1.2",
 		"eslint-plugin-promise": "^4.2.1",
+		"eslint-plugin-standard": "^4.0.1",
 		"prettier": "^1.19.1"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
 	"license": "MIT",
 	"repository": "https://github.com/Qithub-BOT/mastogetter",
 	"scripts": {
-		"eslint": "eslint --ext .js .",
-		"eslint:fix": "eslint --ext .js . --fix",
-		"eslint:ci": "eslint --ext .js --format=html -o ./results/eslint/eslint.html ."
+		"eslint": "eslint --cache --ext .js .",
+		"eslint:fix": "eslint --cache --ext .js . --fix",
+		"eslint:ci": "eslint --cache --ext .js --format=html -o ./results/eslint/eslint.html ."
 	},
 	"devDependencies": {
 		"eslint": "^6.8.0",


### PR DESCRIPTION
- JavaScript Standard Styleの再導入
    - [`yoda`](https://eslint.org/docs/rules/yoda)はoffにしませんでした
    - [`dot-notation`](https://eslint.org/docs/rules/dot-notation#top)**はoffにしませんでした**。
    - [`camelcase`](https://eslint.org/docs/rules/camelcase)は**有効です**。きっと #109 と衝突するでしょう。
- eslint-plugin-jsodcの導入
    - **JSDocを書くことを強制しません**([`jsdoc/require-jsdoc`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-jsdoc)は`off`)。書いてるときだけチェックします。
    - **関数やパラメータ、戻り値の説明を強制しません**([`jsdoc/require-description`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-description), [`jsdoc/require-param-description`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-param-description), [`jsdoc/require-returns-description`](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-returns-description)は`off`)

resolve #84 