### PR TITLE
カード追加時に id が重複しないようにする

### DIFF
--- a/js/class/counter.js
+++ b/js/class/counter.js
@@ -1,0 +1,5 @@
+let count = 0;
+
+export function nextIndex() {
+	return count++;
+}

--- a/js/common.js
+++ b/js/common.js
@@ -118,7 +118,6 @@ export function genPermalink() {
 export function registerEventsToCard(element) {
 	element.addEventListener("dblclick", () => deleteCard(element.id));
 	element.setAttribute("draggable", "true");
-	element.setAttribute("data-dblclickable", "true");
 	element.addEventListener("dragstart", e => handleDragStart(e), false);
 	element.addEventListener("dragover", e => handleDragOver(e), false);
 	element.addEventListener("drop", e => handleDrop(e), false);
@@ -193,7 +192,7 @@ export function handleDrop(e) {
 	}
 	e.dataTransfer.dropEffect = "move";
 	let node = e.target;
-	while (!node.getAttribute("data-dblclickable")) {
+	while (!node.getAttribute("draggable")) {
 		node = node.parentNode;
 	}
 	const src = $(e.dataTransfer.getData("text/plain"));

--- a/js/common.js
+++ b/js/common.js
@@ -14,11 +14,10 @@ function $(id) {
 }
 
 /**
- * @param {number} index
- * @param {string} prefix
+ * @param {string} elementId
  */
-export function deleteCard(index, prefix) {
-	const card = $(`${prefix}_${index}`);
+export function deleteCard(elementId) {
+	const card = $(elementId);
 	const cards = $("cards").childNodes;
 	let idx = 0;
 	for (let i = 0; i < cards.length; i++) {
@@ -115,13 +114,9 @@ export function genPermalink() {
 /**
  *
  * @param {Element} element DOM Element
- * @param {number} index
- * @param {string} prefix
  */
-export function registerEventsToCard(element, index, prefix) {
-	element.addEventListener("dblclick", () => {
-		deleteCard(index, prefix);
-	});
+export function registerEventsToCard(element) {
+	element.addEventListener("dblclick", () => deleteCard(element.id));
 	element.setAttribute("draggable", "true");
 	element.setAttribute("data-dblclickable", "true");
 	element.addEventListener("dragstart", e => handleDragStart(e), false);
@@ -153,7 +148,7 @@ export function showCards(permalinkObj, registerEvent = false) {
 					const tootDiv = createTootDiv(toot);
 					tootDiv.setAttribute("id", `o_${idx}`);
 					if (registerEvent === true) {
-						registerEventsToCard(tootDiv, idx, "o");
+						registerEventsToCard(tootDiv);
 					}
 					maxIndex++;
 					targetDiv.appendChild(tootDiv);

--- a/js/common.js
+++ b/js/common.js
@@ -1,5 +1,6 @@
+import * as counter from "./class/counter.js";
+
 export let cardList = [];
-let maxIndex = 0;
 
 export function ready(loaded) {
 	if (["interactive", "complete"].includes(document.readyState)) {
@@ -143,13 +144,12 @@ export function showCards(permalinkObj, registerEvent = false) {
 			if (xhr.readyState === 4) {
 				if (xhr.status === 200) {
 					const toot = JSON.parse(xhr.responseText);
-					const idx = maxIndex;
+					const idx = counter.nextIndex();
 					const tootDiv = createTootDiv(toot);
 					tootDiv.setAttribute("id", `o_${idx}`);
 					if (registerEvent === true) {
 						registerEventsToCard(tootDiv);
 					}
-					maxIndex++;
 					targetDiv.appendChild(tootDiv);
 				} else {
 					console.error(xhr.statusText);

--- a/js/index.js
+++ b/js/index.js
@@ -1,3 +1,4 @@
+import * as counter from "./class/counter.js";
 import * as impl from "./common.js";
 
 function $(id) {
@@ -37,8 +38,8 @@ function addCard() {
 	const cardPreview = $("card-preview");
 	if (!cardPreview) return;
 	const clone = $("card-preview").firstElementChild.cloneNode(true);
-	const len = impl.cardList.length;
-	clone.setAttribute("id", `c_${len}`);
+	const idx = counter.nextIndex();
+	clone.setAttribute("id", `c_${idx}`);
 	impl.registerEventsToCard(clone);
 	impl.cardList.push(
 		$("toot-id")

--- a/js/index.js
+++ b/js/index.js
@@ -39,7 +39,7 @@ function addCard() {
 	const clone = $("card-preview").firstElementChild.cloneNode(true);
 	const len = impl.cardList.length;
 	clone.setAttribute("id", `c_${len}`);
-	impl.registerEventsToCard(clone, len, "c");
+	impl.registerEventsToCard(clone);
 	impl.cardList.push(
 		$("toot-id")
 			.value.split("/")


### PR DESCRIPTION
# 現象
以下の手順で id が重複していた

1. トゥート ID に2を入力してプレビュー＆トゥート追加
2. 再度 1. を行う
3. 先頭のトゥートをダブルクリックで削除
4. 再度 1. を行う

![image](https://user-images.githubusercontent.com/7685946/72658330-ab7a2880-39f2-11ea-841b-f5b02f4849e2.png)

削除時に id が重複していると、想定と異なるトゥートが削除されてしまう可能性がある

# 対策
`counter` を新規作成して `cardList.length` や `maxIndex` を参照していた箇所を変更した