### PR TITLE
Fetch API を使う

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -168,26 +168,19 @@ export function registerEventsToCard(element) {
 
 /**
  * @param {Request | string} input
- * @returns {Promise<Response>}
+ * @returns {Promise<any>}
  */
-export function fetchJsonAndCheck(input) {
-	return fetch(input)
-		.then(r => {
-			if (r.ok) {
-				return r.json();
-			}
-			throw new Error(`Request failed: ${r.status}`);
-		})
-		.catch(
-			/**
-			 * @param {any} e
-			 * @returns {Response | null}
-			 */
-			e => {
-				console.error(e);
-				return null;
-			}
-		);
+export async function fetchJsonAndCheck(input) {
+	try {
+		const r = await fetch(input);
+		if (r.ok) {
+			return await r.json();
+		}
+		throw new Error(`Request failed: ${r.status}`);
+	} catch (e) {
+		console.error(e);
+		return null;
+	}
 }
 
 /**

--- a/js/index.js
+++ b/js/index.js
@@ -5,7 +5,7 @@ function $(id) {
 	return document.getElementById(id);
 }
 
-function showPreview() {
+async function showPreview() {
 	let instanceFull = $("instance").value;
 	if (instanceFull.trim() === "") {
 		instanceFull = "https://qiitadon.com";
@@ -17,18 +17,9 @@ function showPreview() {
 	if (!tootId) {
 		return;
 	}
-	const tootUrl = `${instanceFull}/api/v1/statuses/${tootId}`;
-	fetch(tootUrl)
-		.then(async response => {
-			if (response.ok) {
-				const toot = await response.json();
-				const tootDiv = impl.createTootDiv(toot);
-				$("card-preview").innerHTML = tootDiv.outerHTML;
-			} else {
-				throw new Error(`Request failed: ${response.status}`);
-			}
-		})
-		.catch(err => console.error(err));
+	const toot = await impl.fetchJsonAndCheck(`${instanceFull}/api/v1/statuses/${tootId}`);
+	const tootDiv = impl.createTootDiv(toot);
+	$("card-preview").innerHTML = tootDiv.outerHTML;
 }
 
 function addCard() {
@@ -79,12 +70,10 @@ function copyPermalink() {
 	document.execCommand("copy");
 }
 
-function loadPermalink() {
+async function loadPermalink() {
 	const permalinkObj = impl.decodePermalink(new URL($("load").value).searchParams);
 	$("instance").value = permalinkObj.instance_full;
-	impl.showCards(permalinkObj, true);
-	// impl.showCardsより前に呼び出してはいけない
-	impl.genPermalink();
+	await impl.showCards(permalinkObj, true).catch(err => console.error(err));
 }
 
 function alertUsageNoPermalink() {
@@ -109,7 +98,7 @@ impl.ready(() => {
 		loadPermalink();
 	});
 	$("showPreview").addEventListener("click", () => {
-		showPreview();
+		showPreview().catch(err => console.error(err));
 	});
 	$("addCard").addEventListener("click", () => {
 		addCard();

--- a/js/index.js
+++ b/js/index.js
@@ -18,6 +18,9 @@ async function showPreview() {
 		return;
 	}
 	const toot = await impl.fetchJsonAndCheck(`${instanceFull}/api/v1/statuses/${tootId}`);
+	if (!toot) {
+		return;
+	}
 	const tootDiv = impl.createTootDiv(toot);
 	$("card-preview").innerHTML = tootDiv.outerHTML;
 }

--- a/js/index.js
+++ b/js/index.js
@@ -14,6 +14,9 @@ function showPreview() {
 	const tootId = $("toot-id")
 		.value.split("/")
 		.reverse()[0];
+	if (!tootId) {
+		return;
+	}
 	const tootUrl = `${instanceFull}/api/v1/statuses/${tootId}`;
 	fetch(tootUrl)
 		.then(async response => {

--- a/js/index.js
+++ b/js/index.js
@@ -14,24 +14,18 @@ function showPreview() {
 	const tootId = $("toot-id")
 		.value.split("/")
 		.reverse()[0];
-	const tootUrl = instanceFull + "/api/v1/statuses/" + tootId;
-	const targetDiv = $("card-preview");
-	const xhr = new XMLHttpRequest();
-	xhr.open("GET", tootUrl, true);
-	xhr.onload = function() {
-		if (xhr.readyState === 4) {
-			if (xhr.status === 200) {
-				const toot = JSON.parse(xhr.responseText);
-				targetDiv.innerHTML = impl.createTootDiv(toot).outerHTML;
+	const tootUrl = `${instanceFull}/api/v1/statuses/${tootId}`;
+	fetch(tootUrl)
+		.then(async response => {
+			if (response.ok) {
+				const toot = await response.json();
+				const tootDiv = impl.createTootDiv(toot);
+				$("card-preview").innerHTML = tootDiv.outerHTML;
 			} else {
-				console.error(xhr.statusText);
+				throw new Error(`Request failed: ${response.status}`);
 			}
-		}
-	};
-	xhr.onerror = function() {
-		console.error(xhr.statusText);
-	};
-	xhr.send(null);
+		})
+		.catch(err => console.error(err));
 }
 
 function addCard() {

--- a/js/index.js
+++ b/js/index.js
@@ -70,10 +70,10 @@ function copyPermalink() {
 	document.execCommand("copy");
 }
 
-async function loadPermalink() {
+function loadPermalink() {
 	const permalinkObj = impl.decodePermalink(new URL($("load").value).searchParams);
 	$("instance").value = permalinkObj.instance_full;
-	await impl.showCards(permalinkObj, true).catch(err => console.error(err));
+	impl.showCards(permalinkObj, true).catch(err => console.error(err));
 }
 
 function alertUsageNoPermalink() {

--- a/js/p.js
+++ b/js/p.js
@@ -1,20 +1,4 @@
 import * as impl from "./common.js";
-function $(id) {
-	return document.getElementById(id);
-}
-
-function showPreview() {
-	impl.showCards(impl.decodePermalink(new URLSearchParams(location.search)));
-	$("matomain").addEventListener("mouseover", removeAllDraggable, false);
-}
-
-function removeAllDraggable() {
-	const elems = document.querySelectorAll("div.toot");
-
-	for (let i = 0; i < elems.length; i++) {
-		elems[i].removeAttribute("draggable");
-	}
-}
 impl.ready(() => {
-	showPreview();
+	impl.showCards(impl.decodePermalink(new URLSearchParams(location.search))).catch(err => console.error(err));
 });


### PR DESCRIPTION
XMLHttpRequest の処理を Fetch API で書き換えました

副産物として、まとめからのインポート処理が非同期で読み込まれるようになりました。
読み込み時間は前よりかは時間がかからなくなったと思います

refs #3 
> 件数が多いまとめを見るときは初期ロードに時間がかかる

テストのときに使ってたサンプルまとめ
https://qithub-bot.github.io/mastogetter/p.html?i=https://qiitadon.com&t=0_1,0_2,0_3,0_4,0_5,0_6,0_7,0_8,0_9,0_a,0_b,0_c,0_d,0_e,0_f,0_g,0_h,0_i,0_j,0_k,0_l,0_m,0_n,0_o,0_p,0_q,0_r,0_s,0_t,0_u,0_v,0_w,0_x,0_y,0_z,0_10