### PR TITLE
chore: 20200322 update npm dependencies

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -54,7 +54,8 @@
 				"singleQuote": false,
 				"trailingComma": "es5",
 				"printWidth": 120,
-				"useTabs": true
+				"useTabs": true,
+				"arrowParens": "avoid"
 			}
 		],
 		"jsdoc/require-description": "off",

--- a/js/index.js
+++ b/js/index.js
@@ -11,9 +11,7 @@ async function showPreview() {
 		instanceFull = "https://qiitadon.com";
 		$("instance").value = instanceFull;
 	}
-	const tootId = $("toot-id")
-		.value.split("/")
-		.reverse()[0];
+	const tootId = $("toot-id").value.split("/").reverse()[0];
 	if (!tootId) {
 		return;
 	}
@@ -32,11 +30,7 @@ function addCard() {
 	const idx = counter.nextIndex();
 	clone.setAttribute("id", `c_${idx}`);
 	impl.registerEventsToCard(clone);
-	impl.cardList.push(
-		$("toot-id")
-			.value.split("/")
-			.reverse()[0]
-	);
+	impl.cardList.push($("toot-id").value.split("/").reverse()[0]);
 
 	if ($("cards").hasChildNodes() && $("cards").firstChild.nodeName === "#text") {
 		$("cards").removeChild($("cards").firstChild);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1146,9 +1146,9 @@
       }
     },
     "eslint-config-standard": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.0.tgz",
-      "integrity": "sha512-EF6XkrrGVbvv8hL/kYa/m6vnvmUT+K82pJJc4JJVMM6+Qgqh0pnwprSxdduDLB9p/7bIxD+YV5O0wfb8lmcPbA==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.1.tgz",
+      "integrity": "sha512-Z9B+VR+JIXRxz21udPTL9HpFMyoMUEeX1G251EQ6e05WD9aPVtVBn09XUmZ259wCMlCDmYDSZG62Hhm+ZTJcUg==",
       "dev": true
     },
     "eslint-import-resolver-node": {
@@ -1338,16 +1338,15 @@
       }
     },
     "eslint-plugin-jsdoc": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-20.4.0.tgz",
-      "integrity": "sha512-c/fnEpwWLFeQn+A7pb1qLOdyhovpqGCWCeUv1wtzFNL5G+xedl9wHUnXtp3b1sGHolVimi9DxKVTuhK/snXoOw==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-22.1.0.tgz",
+      "integrity": "sha512-54NdbICM7KrxsGUqQsev9aIMqPXyvyBx2218Qcm0TQ16P9CtBI+YY4hayJR6adrxlq4Ej0JLpgfUXWaQVFqmQg==",
       "dev": true,
       "requires": {
         "comment-parser": "^0.7.2",
         "debug": "^4.1.1",
         "jsdoctypeparser": "^6.1.0",
         "lodash": "^4.17.15",
-        "object.entries-ponyfill": "^1.0.1",
         "regextras": "^0.7.0",
         "semver": "^6.3.0",
         "spdx-expression-parse": "^3.0.0"
@@ -2459,12 +2458,6 @@
         "object-keys": "^1.0.11"
       }
     },
-    "object.entries-ponyfill": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/object.entries-ponyfill/-/object.entries-ponyfill-1.0.1.tgz",
-      "integrity": "sha1-Kavfd8v70mVm3RqiTp2I9lQz0lY=",
-      "dev": true
-    },
     "object.values": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
@@ -2734,9 +2727,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.1.tgz",
+      "integrity": "sha512-piXGBcY1zoFOG0MvHpNE5reAGseLmaCRifQ/fmfF49BcYkInEs/naD/unxGNAeOKFA5+JxVrPyMvMlpzcd20UA==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -15,15 +15,15 @@
     "ava": "^3.5.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.0",
-    "eslint-config-standard": "^14.1.0",
+    "eslint-config-standard": "^14.1.1",
     "eslint-plugin-import": "^2.20.1",
-    "eslint-plugin-jsdoc": "^20.3.1",
+    "eslint-plugin-jsdoc": "^22.1.0",
     "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
     "esm": "^3.2.25",
-    "prettier": "^1.19.1"
+    "prettier": "^2.0.1"
   },
   "ava": {
     "require": [


### PR DESCRIPTION
pretterのメジャーアップデートで、ちょっと賢くなったようです。
https://prettier.io/blog/2020/03/21/2.0.0.html#improved-method-chain-breaking-heuristic-6685httpsgithubcomprettierprettierpull6685-by-mmkalhttpsgithubcommmkal

`"arrowParens": "avoid"`については
https://prettier.io/blog/2020/03/21/2.0.0.html#change-default-value-for-arrowparens-to-always-7430httpsgithubcomprettierprettierpull7430-by-kachkaevhttpsgithubcomkachkaev